### PR TITLE
Adding Default Message Option to the Whatsapp Button

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
       notificationSound
       notificationDelay={30000}
       darkMode
+      defaultMessage={`Hello, I have a query`}
     />
   )
 }

--- a/src/Components/FloatingWhatsapp.tsx
+++ b/src/Components/FloatingWhatsapp.tsx
@@ -14,6 +14,7 @@ interface FloatingWhatsAppProps {
   avatar?: string
   statusMessage?: string
   chatMessage?: string
+  defaultMessage?: string
   darkMode?: boolean
   allowClickAway?: boolean
   allowEsc?: boolean
@@ -81,6 +82,7 @@ export default function FloatingWhatsApp({
   height = 320,
   avatar = dummyAvatar,
   statusMessage = 'Typically replies within 1 hour',
+  defaultMessage = "Hi, I have a query",
   chatMessage = 'Hello there! 🤝 \nHow can we help?',
   darkMode = false,
   allowClickAway = false,
@@ -96,7 +98,7 @@ export default function FloatingWhatsApp({
     isOpen: false,
     isDelay: true,
     isNotification: false,
-    message: ''
+    message: defaultMessage
   })
 
   if (notificationDelay < 30000) throw new Error('notificationDelay prop value must be at least 30 seconds (30000 ms)')


### PR DESCRIPTION
Added a default message prop to the floating whatsapp button.

### What is now different?
The users can now add a default message which will be populated in the chat by default.

### Reasons for changes
This can be really helpful for e-commerce stores (like ours) wherein we want to prefill the chat with the URL and a few details so that users need not enter them and we save time.

### Anything to watch out for?
I don't think so, I have tested it with example app and it is working fine.

### Screenshots.
Here is a screenshot of the button with the default message prefilled
![image](https://user-images.githubusercontent.com/40917760/155896133-430657dc-5744-4b2f-ad91-5bf5971cbc76.png)

### Note
I would love to update the README with the details of this update once you merge it.
