### PR TITLE
sync aria-hidden and disabled input and button with !isOpen for SEO

### DIFF
--- a/src/components/FloatingWhatsApp.tsx
+++ b/src/components/FloatingWhatsApp.tsx
@@ -226,7 +226,7 @@ export function FloatingWhatsApp({
       <div
         className={`${css.whatsappChatBox} ${isOpen ? css.open : css.close} ${chatboxClassName}`}
         onClick={(event) => event.stopPropagation()}
-        aria-hidden='true'
+        aria-hidden={!isOpen}
         style={{ height: isOpen ? chatboxHeight : 0, ...chatboxStyle }}
       >
         <header className={css.chatHeader}>
@@ -237,7 +237,7 @@ export function FloatingWhatsApp({
             <span className={css.statusTitle}>{accountName}</span>
             <span className={css.statusSubtitle}>{statusMessage}</span>
           </div>
-          <div className={css.close} onClick={handleClose} aria-hidden='true'>
+          <div className={css.close} onClick={handleClose} aria-hidden={!isOpen}>
             <CloseSVG />
           </div>
         </header>
@@ -268,8 +268,8 @@ export function FloatingWhatsApp({
 
         <footer className={css.chatFooter}>
           <form onSubmit={handleSubmit}>
-            <input className={css.input} placeholder={placeholder} ref={inputRef} dir='auto' />
-            <button type='submit' className={css.buttonSend}>
+            <input disabled={!isOpen} className={css.input} placeholder={placeholder} ref={inputRef} dir='auto' />
+            <button disabled={!isOpen} type='submit' className={css.buttonSend}>
               <SendSVG />
             </button>
           </form>


### PR DESCRIPTION
Better SEO of the component.
If an element has "aria-hidden" set to true, its children must not be "focusable".

![image](https://github.com/awran5/react-floating-whatsapp/assets/30082909/23886b35-a1ef-4ecb-b948-13288aa12959)
Base of solution:
https://dequeuniversity.com/rules/axe/4.7/aria-hidden-focus