### PR TITLE
remove aria hidden from button for accessibility improvement

### DIFF
--- a/src/components/FloatingWhatsApp.tsx
+++ b/src/components/FloatingWhatsApp.tsx
@@ -213,7 +213,6 @@ export function FloatingWhatsApp({
         className={`${css.whatsappButton} ${buttonClassName}`}
         onClick={handleOpen}
         style={buttonStyle}
-        aria-hidden='true'
       >
         <WhatsappSVG />
         {isNotification && (
@@ -226,7 +225,6 @@ export function FloatingWhatsApp({
       <div
         className={`${css.whatsappChatBox} ${isOpen ? css.open : css.close} ${chatboxClassName}`}
         onClick={(event) => event.stopPropagation()}
-        aria-hidden='true'
         style={{ height: isOpen ? chatboxHeight : 0, ...chatboxStyle }}
       >
         <header className={css.chatHeader}>
@@ -237,7 +235,7 @@ export function FloatingWhatsApp({
             <span className={css.statusTitle}>{accountName}</span>
             <span className={css.statusSubtitle}>{statusMessage}</span>
           </div>
-          <div className={css.close} onClick={handleClose} aria-hidden='true'>
+          <div className={css.close} onClick={handleClose}>
             <CloseSVG />
           </div>
         </header>


### PR DESCRIPTION
Removing the `aria-hidden` attribute from the button to improve accessibility for screen readers.